### PR TITLE
Switch from safe-buffer to safer-buffer

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+unreleased
+==========
+
+  * Switch from `safe-buffer` to `safer-buffer`
+
 2.0.0 / 2017-09-12
 ==================
 

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@
  * @private
  */
 
-var Buffer = require('safe-buffer').Buffer
+var Buffer = require('safer-buffer').Buffer
 
 /**
  * Module exports.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "repository": "jshttp/basic-auth",
   "dependencies": {
-    "safe-buffer": "5.1.1"
+    "safer-buffer": "2.1.2"
   },
   "devDependencies": {
     "eslint": "4.15.0",


### PR DESCRIPTION
This is in preparation of moving express.js and it's dependencies over to `safer-buffer`.

See expressjs/express#3655 for discussion.