### PR TITLE
Support multiple authentication mechanisms in the header

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ module.exports.parse = parse
  * @private
  */
 
-var CREDENTIALS_REGEXP = /^ *(?:[Bb][Aa][Ss][Ii][Cc]) +([A-Za-z0-9._~+/-]+=*) *$/
+var CREDENTIALS_REGEXP = /\s*(?:[Bb][Aa][Ss][Ii][Cc])\s+([A-Za-z0-9._~+/-]+=*)\s*/
 
 /**
  * RegExp for basic auth user/pass

--- a/test/basic-auth.js
+++ b/test/basic-auth.js
@@ -175,4 +175,14 @@ describe('auth.parse(string)', function () {
       assert.equal(creds.pass, 'pass:word')
     })
   })
+
+  describe('with multiple credentials credentials', function () {
+    it('should return .name and .pass', function () {
+      var JWT_BEARER_TOKEN = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c'
+
+      var creds = auth.parse('bearer ' + JWT_BEARER_TOKEN + ', basic Zm9vOmJhcg==')
+      assert.equal(creds.name, 'foo')
+      assert.equal(creds.pass, 'bar')
+    })
+  })
 })


### PR DESCRIPTION
This PR makes the parser work when the header contains other authorization mechanisms, such as JWT tokens

@fredstrange ^