### PR TITLE
Refactor: Simplify Basic Authentication regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ module.exports.parse = parse
  * @private
  */
 
-var CREDENTIALS_REGEXP = /^ *(?:[Bb][Aa][Ss][Ii][Cc]) +([A-Za-z0-9._~+/-]+=*) *$/
+var CREDENTIALS_REGEXP = /^ *basic +([A-Za-z0-9._~+/-]+=*) *$/i
 
 /**
  * RegExp for basic auth user/pass


### PR DESCRIPTION
- Changed the regex for matching Basic Authentication credentials to use a case-insensitive flag.
- Replaced explicit case handling for Basic with a single lowercase basic and the /i flag for improved readability.