### PR TITLE
Refactor JSDoc for `auth` function: Clarify return type and document errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,8 @@ var USER_PASS_REGEXP = /^([^:]*):(.*)$/
  * Parse the Authorization header field of a request.
  *
  * @param {object} req
- * @return {object} with .name and .pass
+ * @throws {TypeError}
+ * @returns {(Credentials|undefined)}
  * @public
  */
 


### PR DESCRIPTION
Refactor JSDoc for `auth` function: Clarify return type and documented errors

- Refined the return type in JSDoc to `(Credentials|undefined)` to match the actual return value.
- Added `@throws {TypeError}` in JSDoc to document errors thrown for invalid `req` parameter.