### PR TITLE
feat: add support for fetch API `Request` interface

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+unreleased
+==================
+
+  * feat: add support for fetch API `Request` interface
+
 2.0.1 / 2018-09-19
 ==================
 

--- a/index.js
+++ b/index.js
@@ -88,7 +88,12 @@ function getAuthorization (req) {
     throw new TypeError('argument req is required to have headers property')
   }
 
-  return req.headers.authorization
+  if (req.headers.authorization) {
+    return req.headers.authorization
+  } else if (typeof req.headers.get === 'function') {
+    return req.headers.get('authorization')
+  }
+  return undefined
 }
 
 /**

--- a/test/basic-auth.js
+++ b/test/basic-auth.js
@@ -9,6 +9,16 @@ function request (authorization) {
   }
 }
 
+function fetchRequest (authorization) {
+  return {
+    headers: {
+      get: function (name) {
+        return name === 'authorization' ? authorization : undefined
+      }
+    }
+  }
+}
+
 describe('auth(req)', function () {
   describe('arguments', function () {
     describe('req', function () {
@@ -68,6 +78,15 @@ describe('auth(req)', function () {
   describe('with valid credentials', function () {
     it('should return .name and .pass', function () {
       var req = request('basic Zm9vOmJhcg==')
+      var creds = auth(req)
+      assert.strictEqual(creds.name, 'foo')
+      assert.strictEqual(creds.pass, 'bar')
+    })
+  })
+
+  describe('with valid credentials [fetch API Request]', function () {
+    it('should return .name and .pass', function () {
+      var req = fetchRequest('basic Zm9vOmJhcg==')
       var creds = auth(req)
       assert.strictEqual(creds.name, 'foo')
       assert.strictEqual(creds.pass, 'bar')


### PR DESCRIPTION
Currently, the `basic-auth` package supports parsing `Authorization` headers from Node.js `IncomingMessage` objects. However, with the increasing usage of the Fetch API in modern applications (both in server-side environments like Deno, Cloudflare Workers, and Bun, as well as in edge functions), it would be beneficial to extend support to the Fetch API `Request` interface.

### Use Case
In environments like Cloudflare Workers, Deno, and other serverless platforms, request objects conform to the Fetch API standard rather than the Node.js `IncomingMessage` format. Supporting `Request` objects would enable seamless authentication handling in these environments without the need for manual header extraction.

### Proposed Solution
Modify `basic-auth` to accept both `IncomingMessage` and Fetch API `Request` objects. The implementation could check for the presence of `req.headers.get('authorization')` in addition to `req.headers['authorization']` (Node.js style).

### Alternative Workarounds
Currently, users working with Fetch API-based environments must manually extract the `Authorization` header before passing it to `basic-auth`, which adds extra steps and reduces convenience:

```js
const credentials = auth.parse(request.headers.get('authorization'));
```

Adding native support would improve DX (developer experience) and make `basic-auth` more flexible for modern runtimes.