### PR TITLE
Benchmark parse function

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "dist/"
   ],
   "scripts": {
+    "bench": "vitest bench",
     "build": "ts-scripts build",
     "format": "ts-scripts format",
     "lint": "ts-scripts lint",

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,11 +38,10 @@ export function parse(string: string): Credentials | undefined {
   const colonIndex = userPass.indexOf(':');
   if (colonIndex === -1) return undefined;
 
-  // return credentials object
-  return new CredentialsImpl(
-    userPass.slice(0, colonIndex),
-    userPass.slice(colonIndex + 1),
-  );
+  return {
+    name: userPass.slice(0, colonIndex),
+    pass: userPass.slice(colonIndex + 1),
+  };
 }
 
 /**
@@ -64,14 +63,4 @@ const CREDENTIALS_REGEXP =
 
 function decodeBase64(str: string): string {
   return Buffer.from(str, 'base64').toString();
-}
-
-class CredentialsImpl implements Credentials {
-  name: string;
-  pass: string;
-
-  constructor(name: string, pass: string) {
-    this.name = name;
-    this.pass = pass;
-  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,20 +31,18 @@ export function parse(string: string): Credentials | undefined {
 
   // parse header
   const match = CREDENTIALS_REGEXP.exec(string);
-
-  if (!match) {
-    return undefined;
-  }
+  if (!match) return undefined;
 
   // decode user pass
-  const userPass = USER_PASS_REGEXP.exec(decodeBase64(match[1]));
-
-  if (!userPass) {
-    return undefined;
-  }
+  const userPass = decodeBase64(match[1]);
+  const colonIndex = userPass.indexOf(':');
+  if (colonIndex === -1) return undefined;
 
   // return credentials object
-  return new CredentialsImpl(userPass[1], userPass[2]);
+  return new CredentialsImpl(
+    userPass.slice(0, colonIndex),
+    userPass.slice(colonIndex + 1),
+  );
 }
 
 /**
@@ -58,17 +56,6 @@ export function parse(string: string): Credentials | undefined {
 
 const CREDENTIALS_REGEXP =
   /^ *(?:[Bb][Aa][Ss][Ii][Cc]) +([A-Za-z0-9._~+/-]+=*) *$/;
-
-/**
- * RegExp for basic auth user/pass
- *
- * user-pass   = userid ":" password
- * userid      = *<TEXT excluding ":">
- * password    = *TEXT
- * @private
- */
-
-const USER_PASS_REGEXP = /^([^:]*):(.*)$/;
 
 /**
  * Decode base64 string.

--- a/src/parse.bench.ts
+++ b/src/parse.bench.ts
@@ -1,0 +1,24 @@
+import { describe, bench } from 'vitest';
+import { parse } from './index';
+
+describe('parse', () => {
+  bench('basic auth header', () => {
+    const header = 'Basic dGVzdDpwYXNzd29yZA=='; // "test:password" in base64
+    parse(header);
+  });
+
+  bench('basic auth header with extra whitespace', () => {
+    const header = '   Basic   dGVzdDpwYXNzd29yZA==   '; // "test:password" in base64 with extra whitespace
+    parse(header);
+  });
+
+  bench('invalid basic auth header', () => {
+    const header = 'Basic invalidbase64'; // Invalid base64 string
+    parse(header);
+  });
+
+  bench('non-basic auth header', () => {
+    const header = 'Bearer sometoken'; // Not a basic auth header
+    parse(header);
+  });
+});


### PR DESCRIPTION
Add a benchmark utility, remove user:pass regex in favor of simple `indexOf`. Somewhat faster.

Before:

```
     name                                                hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · basic auth header                         2,051,649.51  0.0003  1.5729  0.0005  0.0004  0.0012  0.0014  0.0141  ±1.34%  1025825
   · basic auth header with extra whitespace   2,353,509.46  0.0003  0.2861  0.0004  0.0004  0.0005  0.0006  0.0016  ±0.32%  1176755
   · invalid basic auth header                 2,470,888.19  0.0002  0.4685  0.0004  0.0004  0.0005  0.0011  0.0025  ±0.63%  1235445
   · non-basic auth header                    17,442,921.02  0.0000  0.4710  0.0001  0.0001  0.0001  0.0001  0.0002  ±0.34%  8721461
```

After:

```
 ✓ src/parse.bench.ts > parse 6339ms
     name                                                hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · basic auth header                         2,386,295.98  0.0003  0.6112  0.0004  0.0004  0.0011  0.0011  0.0021  ±0.64%  1193148
   · basic auth header with extra whitespace   2,426,362.48  0.0003  0.3008  0.0004  0.0004  0.0005  0.0005  0.0011  ±0.30%  1213182
   · invalid basic auth header                 2,667,422.31  0.0002  0.2500  0.0004  0.0004  0.0005  0.0005  0.0010  ±0.27%  1333712
   · non-basic auth header                    16,981,965.93  0.0000  2.4181  0.0001  0.0001  0.0001  0.0001  0.0002  ±0.97%  8490983
```

I also made an attempt with a parser similar to `cookie`, `content-type`, etc but the perf gains vs complexity/code overhead doesn't seem to be worth it, the `indexOf` is pretty small in comparison.