### PR TITLE
Export as ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "basic-auth",
   "version": "2.0.1",
-  "description": "node.js basic auth parser",
+  "description": "Basic auth parser",
   "keywords": [
     "basic",
     "auth",
@@ -10,10 +10,8 @@
   ],
   "repository": "jshttp/basic-auth",
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "exports": "./dist/index.js",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
   "files": [
     "dist/"
   ],

--- a/src/format.bench.ts
+++ b/src/format.bench.ts
@@ -1,5 +1,5 @@
 import { bench, describe } from 'vitest';
-import { format } from './index';
+import { format } from './index.js';
 
 describe('format', () => {
   bench('format with simple credentials', () => {

--- a/src/format.spec.ts
+++ b/src/format.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, assert } from 'vitest';
-import { format } from './index';
+import { format } from './index.js';
 
 describe('format(credentials)', function () {
   describe('arguments', function () {

--- a/src/parse.bench.ts
+++ b/src/parse.bench.ts
@@ -1,5 +1,5 @@
 import { describe, bench } from 'vitest';
-import { parse } from './index';
+import { parse } from './index.js';
 
 describe('parse', () => {
   bench('basic auth header', () => {

--- a/src/parse.spec.ts
+++ b/src/parse.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, assert } from 'vitest';
-import { parse } from './index';
+import { parse } from './index.js';
 
 describe('parse(string)', function () {
   describe('with undefined string', function () {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "extends": "@borderless/ts-scripts/configs/tsconfig.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "lib": ["ES2023"],
+    "target": "es2023",
+    "lib": ["es2023"],
     "rootDir": "src",
     "outDir": "dist",
     "module": "nodenext",


### PR DESCRIPTION
Discussed with TC, the plan is that all utilities will become ESM _unless_ there's a valuable reason to release for Express 5 specifically. Since the current version is used without any real maintenance overhead, I think we should move to ESM for the next major release.