### PR TITLE
Update error message and throw on `parse` non-string

### DIFF
--- a/src/format.spec.ts
+++ b/src/format.spec.ts
@@ -5,7 +5,10 @@ describe('format(credentials)', function () {
   describe('arguments', function () {
     describe('credentials', function () {
       it('should be required', function () {
-        assert.throws(() => (format as any)(), /credentials is required/);
+        assert.throws(
+          () => (format as any)(),
+          /"credentials" must be an object/,
+        );
       });
 
       it('should accept credentials', function () {
@@ -16,43 +19,49 @@ describe('format(credentials)', function () {
       it('should reject null', function () {
         assert.throws(
           format.bind(null, null as any),
-          /credentials is required/,
+          /"credentials" must be an object/,
         );
       });
 
       it('should reject a number', function () {
-        assert.throws(format.bind(null, 42 as any), /credentials is required/);
+        assert.throws(
+          format.bind(null, 42 as any),
+          /"credentials" must be an object/,
+        );
       });
 
       it('should reject a string', function () {
-        assert.throws(format.bind(null, '' as any), /credentials is required/);
+        assert.throws(
+          format.bind(null, '' as any),
+          /"credentials" must be an object/,
+        );
       });
 
       it('should reject an object without name', function () {
         assert.throws(
           format.bind(null, { pass: 'bar' } as any),
-          /credentials is required to have name and pass properties/,
+          /"credentials" must have string properties "name" and "pass"/,
         );
       });
 
       it('should reject an object without pass', function () {
         assert.throws(
           format.bind(null, { name: 'foo' } as any),
-          /credentials is required to have name and pass properties/,
+          /"credentials" must have string properties "name" and "pass"/,
         );
       });
 
       it('should reject an object with non-string name', function () {
         assert.throws(
           format.bind(null, { name: 42, pass: 'bar' } as any),
-          /credentials is required to have name and pass properties/,
+          /"credentials" must have string properties "name" and "pass"/,
         );
       });
 
       it('should reject an object with non-string pass', function () {
         assert.throws(
           format.bind(null, { name: 'foo', pass: 42 } as any),
-          /credentials is required to have name and pass properties/,
+          /"credentials" must have string properties "name" and "pass"/,
         );
       });
 
@@ -87,21 +96,21 @@ describe('format(credentials)', function () {
   });
 
   describe('with empty password', function () {
-    it('should throw', function () {
+    it('should return header', function () {
       const header = format({ name: 'foo', pass: '' });
       assert.strictEqual(header, 'Basic Zm9vOg==');
     });
   });
 
   describe('with empty userid', function () {
-    it('should throw', function () {
+    it('should return header', function () {
       const header = format({ name: '', pass: 'pass' });
       assert.strictEqual(header, 'Basic OnBhc3M=');
     });
   });
 
   describe('with empty userid and pass', function () {
-    it('should throw', function () {
+    it('should return header', function () {
       const header = format({ name: '', pass: '' });
       assert.strictEqual(header, 'Basic Og==');
     });

--- a/src/format.spec.ts
+++ b/src/format.spec.ts
@@ -5,10 +5,7 @@ describe('format(credentials)', function () {
   describe('arguments', function () {
     describe('credentials', function () {
       it('should be required', function () {
-        assert.throws(
-          () => (format as any)(),
-          /argument credentials is required/,
-        );
+        assert.throws(() => (format as any)(), /credentials is required/);
       });
 
       it('should accept credentials', function () {
@@ -19,63 +16,57 @@ describe('format(credentials)', function () {
       it('should reject null', function () {
         assert.throws(
           format.bind(null, null as any),
-          /argument credentials is required/,
+          /credentials is required/,
         );
       });
 
       it('should reject a number', function () {
-        assert.throws(
-          format.bind(null, 42 as any),
-          /argument credentials is required/,
-        );
+        assert.throws(format.bind(null, 42 as any), /credentials is required/);
       });
 
       it('should reject a string', function () {
-        assert.throws(
-          format.bind(null, '' as any),
-          /argument credentials is required/,
-        );
+        assert.throws(format.bind(null, '' as any), /credentials is required/);
       });
 
       it('should reject an object without name', function () {
         assert.throws(
           format.bind(null, { pass: 'bar' } as any),
-          /argument credentials is required to have name and pass properties/,
+          /credentials is required to have name and pass properties/,
         );
       });
 
       it('should reject an object without pass', function () {
         assert.throws(
           format.bind(null, { name: 'foo' } as any),
-          /argument credentials is required to have name and pass properties/,
+          /credentials is required to have name and pass properties/,
         );
       });
 
       it('should reject an object with non-string name', function () {
         assert.throws(
           format.bind(null, { name: 42, pass: 'bar' } as any),
-          /argument credentials is required to have name and pass properties/,
+          /credentials is required to have name and pass properties/,
         );
       });
 
       it('should reject an object with non-string pass', function () {
         assert.throws(
           format.bind(null, { name: 'foo', pass: 42 } as any),
-          /argument credentials is required to have name and pass properties/,
+          /credentials is required to have name and pass properties/,
         );
       });
 
       it('should reject userid containing colon', function () {
         assert.throws(
           format.bind(null, { name: 'foo:bar', pass: 'baz' }),
-          /must not contain a colon or control characters/,
+          /must not contain a colon/,
         );
       });
 
       it('should reject control chars in userid', function () {
         assert.throws(
           format.bind(null, { name: 'foo\u0000bar', pass: 'baz' }),
-          /must not contain a colon or control characters/,
+          /must not contain control characters/,
         );
       });
 

--- a/src/format.spec.ts
+++ b/src/format.spec.ts
@@ -5,10 +5,7 @@ describe('format(credentials)', function () {
   describe('arguments', function () {
     describe('credentials', function () {
       it('should be required', function () {
-        assert.throws(
-          () => (format as any)(),
-          /"credentials" must be an object/,
-        );
+        assert.throws(() => (format as any)(), /Expected an object/);
       });
 
       it('should accept credentials', function () {
@@ -17,51 +14,42 @@ describe('format(credentials)', function () {
       });
 
       it('should reject null', function () {
-        assert.throws(
-          format.bind(null, null as any),
-          /"credentials" must be an object/,
-        );
+        assert.throws(format.bind(null, null as any), /Expected an object/);
       });
 
       it('should reject a number', function () {
-        assert.throws(
-          format.bind(null, 42 as any),
-          /"credentials" must be an object/,
-        );
+        assert.throws(format.bind(null, 42 as any), /Expected an object/);
       });
 
       it('should reject a string', function () {
-        assert.throws(
-          format.bind(null, '' as any),
-          /"credentials" must be an object/,
-        );
+        assert.throws(format.bind(null, '' as any), /Expected an object/);
       });
 
       it('should reject an object without name', function () {
         assert.throws(
           format.bind(null, { pass: 'bar' } as any),
-          /"credentials" must have string properties "name" and "pass"/,
+          /Object must have string properties "name" and "pass"/,
         );
       });
 
       it('should reject an object without pass', function () {
         assert.throws(
           format.bind(null, { name: 'foo' } as any),
-          /"credentials" must have string properties "name" and "pass"/,
+          /Object must have string properties "name" and "pass"/,
         );
       });
 
       it('should reject an object with non-string name', function () {
         assert.throws(
           format.bind(null, { name: 42, pass: 'bar' } as any),
-          /"credentials" must have string properties "name" and "pass"/,
+          /Object must have string properties "name" and "pass"/,
         );
       });
 
       it('should reject an object with non-string pass', function () {
         assert.throws(
           format.bind(null, { name: 'foo', pass: 42 } as any),
-          /"credentials" must have string properties "name" and "pass"/,
+          /Object must have string properties "name" and "pass"/,
         );
       });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,12 +52,8 @@ export function parse(string: string): Credentials | undefined {
  * @public
  */
 export function format(credentials: Credentials): string {
-  if (!credentials) {
-    throw new TypeError('argument credentials is required');
-  }
-
-  if (typeof credentials !== 'object') {
-    throw new TypeError('argument credentials is required to be an object');
+  if (typeof credentials !== 'object' || credentials === null) {
+    throw new TypeError('credentials is required to be an object');
   }
 
   if (
@@ -65,26 +61,24 @@ export function format(credentials: Credentials): string {
     typeof credentials.pass !== 'string'
   ) {
     throw new TypeError(
-      'argument credentials is required to have name and pass properties',
+      'credentials is required to have name and pass properties',
     );
   }
 
-  if (
-    credentials.name.includes(':') || // RFC 7617 disallows colon in username
-    CONTROL_CHARS_REGEXP.test(credentials.name)
-  ) {
+  // RFC 7617 disallows colon in username
+  if (credentials.name.includes(':')) {
+    throw new TypeError('name must not contain a colon');
+  }
+
+  const str = credentials.name + ':' + credentials.pass;
+
+  if (CONTROL_CHARS_REGEXP.test(str)) {
     throw new TypeError(
-      'argument credentials.name must not contain a colon or control characters',
+      'argument credentials must not contain control characters',
     );
   }
 
-  if (CONTROL_CHARS_REGEXP.test(credentials.pass)) {
-    throw new TypeError(
-      'argument credentials.pass must not contain control characters',
-    );
-  }
-
-  return 'Basic ' + base64.encode(credentials.name + ':' + credentials.pass);
+  return 'Basic ' + base64.encode(str);
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,7 @@ export function parse(string: string): Credentials | undefined {
  */
 export function format(credentials: Credentials): string {
   if (typeof credentials !== 'object' || credentials === null) {
-    throw new TypeError('credentials is required to be an object');
+    throw new TypeError('"credentials" must be an object');
   }
 
   if (
@@ -61,20 +61,20 @@ export function format(credentials: Credentials): string {
     typeof credentials.pass !== 'string'
   ) {
     throw new TypeError(
-      'credentials is required to have name and pass properties',
+      '"credentials" must have string properties "name" and "pass"',
     );
   }
 
   // RFC 7617 disallows colon in username
   if (credentials.name.includes(':')) {
-    throw new TypeError('name must not contain a colon');
+    throw new TypeError('"name" must not contain a colon');
   }
 
   const str = credentials.name + ':' + credentials.pass;
 
   if (CONTROL_CHARS_REGEXP.test(str)) {
     throw new TypeError(
-      'argument credentials must not contain control characters',
+      '"name" and "pass" must not contain control characters',
     );
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ export interface Credentials {
 
 export function parse(string: string): Credentials | undefined {
   if (typeof string !== 'string') {
-    return undefined;
+    throw new TypeError('Expected a string');
   }
 
   // parse header
@@ -53,28 +53,26 @@ export function parse(string: string): Credentials | undefined {
  */
 export function format(credentials: Credentials): string {
   if (typeof credentials !== 'object' || credentials === null) {
-    throw new TypeError('"credentials" must be an object');
+    throw new TypeError('Expected an object');
   }
 
   if (
     typeof credentials.name !== 'string' ||
     typeof credentials.pass !== 'string'
   ) {
-    throw new TypeError(
-      '"credentials" must have string properties "name" and "pass"',
-    );
+    throw new TypeError('Object must have string properties "name" and "pass"');
   }
 
   // RFC 7617 disallows colon in username
   if (credentials.name.includes(':')) {
-    throw new TypeError('"name" must not contain a colon');
+    throw new TypeError('Object "name" must not contain a colon');
   }
 
   const str = credentials.name + ':' + credentials.pass;
 
   if (CONTROL_CHARS_REGEXP.test(str)) {
     throw new TypeError(
-      '"name" and "pass" must not contain control characters',
+      'Object "name" and "pass" must not contain control characters',
     );
   }
 

--- a/src/parse.spec.ts
+++ b/src/parse.spec.ts
@@ -2,9 +2,9 @@ import { describe, it, assert } from 'vitest';
 import { parse } from './index.js';
 
 describe('parse(string)', function () {
-  describe('with undefined string', function () {
-    it('should return undefined', function () {
-      assert.strictEqual((parse as any)(), undefined);
+  describe('with non string', function () {
+    it('should throw', function () {
+      assert.throws(() => parse(undefined as any), /Expected a string/);
     });
   });
 


### PR DESCRIPTION
Marginal perf bump by validating control characters together. Small simplification on object validation for bytes.

Before:

```
 ✓ src/format.bench.ts > format 4276ms
     name                                       hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · format with simple credentials   3,758,643.72  0.0001  3.4189  0.0003  0.0003  0.0003  0.0004  0.0015  ±1.43%  1879322
   · format with long credentials     2,887,119.72  0.0002  0.2407  0.0003  0.0003  0.0004  0.0005  0.0026  ±0.34%  1443560
   · format with unicode credentials  3,628,485.19  0.0002  0.2014  0.0003  0.0003  0.0003  0.0004  0.0010  ±0.30%  1814243
   · format with special characters   3,538,610.78  0.0002  6.7937  0.0003  0.0003  0.0003  0.0004  0.0014  ±2.68%  1769306
```

After:

```
 ✓ src/format.bench.ts > format 4275ms
     name                                       hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · format with simple credentials   3,810,883.80  0.0002  0.6533  0.0003  0.0003  0.0003  0.0004  0.0015  ±0.34%  1905442
   · format with long credentials     2,866,106.83  0.0002  0.2182  0.0003  0.0003  0.0004  0.0005  0.0014  ±0.34%  1433054
   · format with unicode credentials  3,657,358.93  0.0002  0.3126  0.0003  0.0003  0.0003  0.0004  0.0008  ±0.32%  1828680
   · format with special characters   3,490,155.23  0.0002  0.1538  0.0003  0.0003  0.0003  0.0004  0.0009  ±0.27%  1745078
```

It's not a huge improvement so we could just leave it, but I don't see any reason not to include it 🤷 